### PR TITLE
Corregí el valor devuelto por la función Vector_bsearch

### DIFF
--- a/TPGame.cscope_file_list
+++ b/TPGame.cscope_file_list
@@ -1,0 +1,6 @@
+"D:\Projects\C_Projects\UNLAM\Topicos\TPGame\structures\Entities.h"
+"D:\Projects\C_Projects\UNLAM\Topicos\TPGame\structures\Vector.h"
+"D:\Projects\C_Projects\UNLAM\Topicos\TPGame\structures\Game.c"
+"D:\Projects\C_Projects\UNLAM\Topicos\TPGame\main.c"
+"D:\Projects\C_Projects\UNLAM\Topicos\TPGame\structures\Vector.c"
+"D:\Projects\C_Projects\UNLAM\Topicos\TPGame\structures\Game.h"

--- a/structures/Vector.c
+++ b/structures/Vector.c
@@ -52,8 +52,9 @@ int Vector_insertInOrder(Vector* v, void* elemento, size_t tamDato, Cmp cmp) {
 
     return 1;
 }
+
 // Función de búsqueda binaria
-tNodo* Vector_bsearch(Vector* v, void* valor, Cmp cmp) {
+void* Vector_bsearch(Vector* v, void* valor, Cmp cmp) {
     tNodo* ini = v->vec;
     tNodo* fin = v->vec + v->ce - 1;
 
@@ -62,7 +63,7 @@ tNodo* Vector_bsearch(Vector* v, void* valor, Cmp cmp) {
         int comp = cmp(valor, medio->dato);
 
         if (comp == 0) {
-            return medio;  // Se encontró el valor
+            return medio->dato;  // Se encontró el valor
         } else if (comp > 0) {
             ini = medio + 1;
         } else {

--- a/structures/Vector.h
+++ b/structures/Vector.h
@@ -24,6 +24,6 @@ void Vector_destroy(Vector*v);
 int _resize(Vector* v,size_t nuevoTamanio);
 int Vector_insertInOrder(Vector* v,void*elemento,size_t tamDato,Cmp cmp);
 int Vector_getByPos(Vector* v, int pos, void * valor, size_t tamValor);
-tNodo* Vector_bsearch(Vector *v, void * valor, Cmp cmp);
+void* Vector_bsearch(Vector *v, void * valor, Cmp cmp);
 int compararInt(const void* a, const void* b);
 #endif // VECTOR_H_INCLUDED


### PR DESCRIPTION
Cambié la función Vector_bsearch para que devuelva void* en lugar de tNodo*, de modo que el usuario reciba directamente el dato buscado sin conocer detalles de la estructura interna.
Closes #3